### PR TITLE
Fix an error when working with a single cell using the ParseNumerics Function.

### DIFF
--- a/NavfertyExcelAddIn/Commons/EnumerableExtensions.cs
+++ b/NavfertyExcelAddIn/Commons/EnumerableExtensions.cs
@@ -49,38 +49,41 @@ namespace NavfertyExcelAddIn.Commons
                 return;
             }
 
-            // minimize number of COM calls to excel
-            var values = (object[,])rangeValue;
-
-            int upperI = values.GetUpperBound(0); // Columns
-            int upperJ = values.GetUpperBound(1); // Rows
-
-            var isChanged = false;
-
-            logger.Debug($"Converting columns from {values.GetLowerBound(0)} to {upperI}, " +
-                $"rows from {values.GetLowerBound(1)} to {upperJ}");
-
-            for (int i = values.GetLowerBound(0); i <= upperI; i++)
+            if (!(rangeValue is double))
             {
-                for (int j = values.GetLowerBound(1); j <= upperJ; j++)
+                // minimize number of COM calls to excel
+                var values = (object[,])rangeValue;
+
+                int upperI = values.GetUpperBound(0); // Columns
+                int upperJ = values.GetUpperBound(1); // Rows
+
+                var isChanged = false;
+
+                logger.Debug($"Converting columns from {values.GetLowerBound(0)} to {upperI}, " +
+                    $"rows from {values.GetLowerBound(1)} to {upperJ}");
+
+                for (int i = values.GetLowerBound(0); i <= upperI; i++)
                 {
-                    var value = values[i, j];
-                    if (value is TIn s)
+                    for (int j = values.GetLowerBound(1); j <= upperJ; j++)
                     {
-                        var newValue = transform(s);
-                        if ((object)newValue != value) // TODO check boxing time on million values
+                        var value = values[i, j];
+                        if (value is TIn s)
                         {
-                            isChanged = true;
-                            values[i, j] = newValue;
+                            var newValue = transform(s);
+                            if ((object)newValue != value) // TODO check boxing time on million values
+                            {
+                                isChanged = true;
+                                values[i, j] = newValue;
+                            }
                         }
                     }
                 }
-            }
 
-            if (isChanged)
-            {
-                logger.Debug("Some values were converted, writing to worksheet");
-                range.Value = values;
+                if (isChanged)
+                {
+                    logger.Debug("Some values were converted, writing to worksheet");
+                    range.Value = values;
+                }
             }
         }
     }

--- a/NavfertyExcelAddIn/Commons/EnumerableExtensions.cs
+++ b/NavfertyExcelAddIn/Commons/EnumerableExtensions.cs
@@ -53,8 +53,6 @@ namespace NavfertyExcelAddIn.Commons
             if (!(rangeValue is object[,] values))
                 return;
 
-            values = (object[,])rangeValue;
-
             int upperI = values.GetUpperBound(0); // Columns
             int upperJ = values.GetUpperBound(1); // Rows
 


### PR DESCRIPTION
If the cell value is already represented in decimal (double) form, the function stops working further.
```
if (!(rangeValue is double))
{
//code
//...
//...
}
```
It's a blunt crutch, please don't laugh.